### PR TITLE
Add PostgreSQL service and dotenv dependency

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 # Use Docker Compose file format version 3.9
-version: '3.9'
+version: "3.9"
 
 services:
   # Define the service named 'app'
@@ -12,7 +12,20 @@ services:
     container_name: nextjs14-container
     # Map port 3000 on the host to port 3000 in the container
     ports:
-      - '3000:3000'
+      - "3000:3000"
     # Avoid mounting node_modules from the host to the container
     volumes:
       - /app/node_modules
+  drizzle-db:
+    image: postgres
+    restart: always
+    container_name: drizzle-db
+    ports:
+      - 5432:5432
+    environment:
+      POSTGRES_PASSWORD: example
+      PGDATA: /data/postgres
+    volumes:
+      - postgres:/data/postgres
+volumes:
+  postgres:

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,0 +1,13 @@
+import { config } from 'dotenv';
+import { defineConfig } from 'drizzle-kit';
+
+config({ path: '.env.local' });
+
+export default defineConfig({
+  schema: './src/db/schema.ts',
+  out: './migrations',
+  dialect: 'postgresql',
+  dbCredentials: {
+    url: process.env.DATABASE_URL!,
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "canvas-llm-builder",
       "version": "0.1.0",
       "dependencies": {
+        "dotenv": "^16.4.7",
         "drizzle-orm": "^0.41.0",
         "next": "15.2.4",
         "postgres": "^3.4.5",
@@ -3128,6 +3129,18 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/drizzle-kit": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "db:push": "npx drizzle-kit push --config=drizzle.config.ts"
   },
   "dependencies": {
+    "dotenv": "^16.4.7",
     "drizzle-orm": "^0.41.0",
     "next": "15.2.4",
     "postgres": "^3.4.5",


### PR DESCRIPTION
- Configure PostgreSQL container in docker-compose.yml with volume persistence
- Add dotenv dependency for environment variable management
- Update docker-compose formatting to use double quotes consistently